### PR TITLE
[Indigo] Initial version GazeboRosControlPlugin with Multi-HWInterface-Support

### DIFF
--- a/cob_gazebo_plugins/CMakeLists.txt
+++ b/cob_gazebo_plugins/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cob_gazebo_plugins)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/cob_gazebo_plugins/package.xml
+++ b/cob_gazebo_plugins/package.xml
@@ -1,0 +1,25 @@
+<package>
+  <name>cob_gazebo_plugins</name>
+  <version>0.6.0</version>
+  <description>cob_gazebo_plugins meta-package</description>
+
+
+  <license>LGPL</license>
+
+  <url type="website">http://ros.org/wiki/cob_gazebo_plugins</url>
+  <!-- <url type="bugtracker"></url> -->
+
+  <maintainer email="fmw@ipa.fhg.de">Florian Weisshardt</maintainer>
+  <maintainer email="nhg@ipa.fhg.de">Nadia Hammoudeh Garcia</maintainer>
+  <maintainer email="fxm@ipa.fhg.de">Felix Messmer</maintainer>
+
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>cob_gazebo_ros_control</run_depend>
+
+
+
+  <export>
+    <metapackage/>
+  </export>
+</package>

--- a/cob_gazebo_ros_control/CMakeLists.txt
+++ b/cob_gazebo_ros_control/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cob_gazebo_ros_control)
+
+# Load catkin and all dependencies required for this package
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  control_toolbox
+  controller_manager
+  hardware_interface 
+  transmission_interface
+  pluginlib
+  joint_limits_interface
+  urdf
+  angles
+  gazebo_ros_control
+)
+
+# Depend on system install of Gazebo 
+find_package(gazebo REQUIRED)
+
+catkin_package(
+  CATKIN_DEPENDS
+    roscpp
+    controller_manager
+    pluginlib
+    transmission_interface
+    gazebo_ros_control
+  INCLUDE_DIRS include
+  LIBRARIES multi_hw_interface_gazebo_ros_control multi_hw_interface_robot_hw_sim
+  DEPENDS gazebo
+)
+
+#link_directories(${GAZEBO_LIBRARY_DIRS})
+include_directories(include
+  ${Boost_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+)
+
+## Libraries
+add_library(multi_hw_interface_gazebo_ros_control src/multi_hw_interface_gazebo_ros_control_plugin.cpp)
+target_link_libraries(multi_hw_interface_gazebo_ros_control ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+
+add_library(multi_hw_interface_robot_hw_sim src/multi_hw_interface_robot_hw_sim.cpp)
+target_link_libraries(multi_hw_interface_robot_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+
+## Install
+install(TARGETS multi_hw_interface_gazebo_ros_control multi_hw_interface_robot_hw_sim
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  )
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  )
+
+install(FILES cob_gazebo_ros_control_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  )
+

--- a/cob_gazebo_ros_control/README.md
+++ b/cob_gazebo_ros_control/README.md
@@ -11,7 +11,8 @@ This plugin has originally been discussed and proposed [here](https://github.com
 
 Besides the features provided by the default ```gazebo_ros_control``` plugin, this plugin here adds the following additional features:
  - Support for multiple HardwareInterfaces
- 
+
+--- 
  
 ## Usage
 
@@ -51,7 +52,9 @@ With this plugin, you can now specify multiple HardwareInterfaces for the transm
 ```
 You can specify any HardwareInterface out of [```PositionJointInterface```, ```VelocityJointInterface```, ```EffortJointInterface```]. The order of does not matter.  
 
----
+--- 
+ 
+## Benefit
 
 This plugin allows to use ros\_controllers requiring different HardwareInterfaces within the same gazebo session.  
 (No need to change the URDF for a different control_mode).

--- a/cob_gazebo_ros_control/README.md
+++ b/cob_gazebo_ros_control/README.md
@@ -1,0 +1,40 @@
+# Gazebo ros_control Interfaces
+
+This is a ROS package for integrating the `ros_control` controller architecture
+with the [Gazebo](http://gazebosim.org/) simulator. 
+
+This package provides a Gazebo plugin which instantiates a ros_control
+controller manager and connects it to a Gazebo model.
+
+It extends the default plugin available in [gazebo_ros_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control).
+This plugin has originally been proposed [here](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256).
+
+Besides the features provided by the default plugin, it adds the following additional features:
+ - Support for multiple HardwareInterfaces
+ 
+ 
+## Usage
+
+[Documentation](http://gazebosim.org/tutorials?tut=ros_control&cat=connect_ros) related to the default plugin is provided on Gazebo's website.
+
+To use the plugin, add the following to your robot's URDF:
+
+```
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libmulti_hw_interface_gazebo_ros_control.so">
+      <robotNamespace>NAMESPACE</robotNamespace>
+    </plugin>
+  </gazebo>
+```
+
+The ```robotNamespace``` is used as a prefix for the ```controller_manager``` instantiated by the plugin.
+I.e. the services will be advertised under /NAMESPACE/controller_manager.
+(NOTE: Do not use a trailing '/' before NAMESPACE!)
+
+You can also use ```robotParam``` and ```controlPeriod``` as for the default gazebo\_ros\_control plugin.
+
+However, ```robotSimType``` is __ignored__ as the plugin depends on the HardwareInterface ```MultiHWInterfaceRobotHWSim``` which is also provided in this package.
+
+
+
+

--- a/cob_gazebo_ros_control/README.md
+++ b/cob_gazebo_ros_control/README.md
@@ -6,10 +6,10 @@ with the [Gazebo](http://gazebosim.org/) simulator.
 This package provides a Gazebo plugin which instantiates a ros_control
 controller manager and connects it to a Gazebo model.
 
-It extends the default plugin available in [gazebo_ros_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control).
-This plugin has originally been proposed [here](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256).
+It extends the default plugin available in [gazebo_ros_control](https://github.com/ros-simulation/gazebo_ros_pkgs/tree/indigo-devel/gazebo_ros_control).  
+This plugin has originally been discussed and proposed [here](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256).
 
-Besides the features provided by the default plugin, it adds the following additional features:
+Besides the features provided by the default ```gazebo_ros_control``` plugin, this plugin here adds the following additional features:
  - Support for multiple HardwareInterfaces
  
  
@@ -27,14 +27,48 @@ To use the plugin, add the following to your robot's URDF:
   </gazebo>
 ```
 
-The ```robotNamespace``` is used as a prefix for the ```controller_manager``` instantiated by the plugin.
-I.e. the services will be advertised under /NAMESPACE/controller_manager.
-(NOTE: Do not use a trailing '/' before NAMESPACE!)
+The ```robotNamespace``` is used as a prefix for the ```controller_manager``` instantiated by the plugin.  
+The tag is optional and will default to global namespace '/' if not set.  
+In the example above the services will be advertised under ```/NAMESPACE/controller_manager```.  
+__NOTE__: Do not use a trailing '/' before NAMESPACE!
 
-You can also use ```robotParam``` and ```controlPeriod``` as for the default gazebo\_ros\_control plugin.
+You can also use the tags ```robotParam``` and ```controlPeriod``` as for the default plugin.
 
-However, ```robotSimType``` is __ignored__ as the plugin depends on the HardwareInterface ```MultiHWInterfaceRobotHWSim``` which is also provided in this package.
+The tag ```robotSimType``` is ignored and defaults to ```cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim``` which is a specialized HardwareInterface which is also provided in this package. ```MultiHWInterfaceRobotHWSim``` derives from ```DefaultRobotHWSim``` of the default plugin.  
 
+With this plugin, you can now specify multiple HardwareInterfaces for the transmissions of your joints, like this:  
+```
+    <transmission name="arm_1_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="arm_1_joint">
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="arm_1_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+```
+You can specify any HardwareInterface out of [```PositionJointInterface```, ```VelocityJointInterface```, ```EffortJointInterface```]. The order of does not matter.  
 
+---
 
+This plugin allows to use ros\_controllers requiring different HardwareInterfaces within the same gazebo session.  
+(No need to change the URDF for a different control_mode).
 
+For example:
+```
+#position controller
+arm_1_joint_position_controller:
+  type: position_controllers/JointPositionController
+  joint: arm_1_joint
+
+#velocity controller
+arm_1_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: arm_1_joint
+```
+
+can be loaded to the parameter server (under the NAMESPACE of the controller\_manager) and then those two controllers can be switched using the ControllerManagers ```switch_controller```-Service "on-the-fly".
+
+A side-benefit of this is that no "PID-Parameter-Tuning" would be required for simulation anymore, as gazebo supports all the (Standard-)HardwareInterfaces. 

--- a/cob_gazebo_ros_control/cob_gazebo_ros_control_plugins.xml
+++ b/cob_gazebo_ros_control/cob_gazebo_ros_control_plugins.xml
@@ -1,0 +1,12 @@
+<library path="lib/libmulti_hw_interface_robot_hw_sim">
+  <class
+    name="cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim"
+    type="cob_gazebo_ros_control::MultiHWInterfaceRobotHWSim"
+    base_class_type="gazebo_ros_control::RobotHWSim">
+    <description>
+      A robot simulation interface which constructs joint handles from an SDF/URDF supporting hardware_interface switching.
+    </description>
+  </class>
+</library>
+
+

--- a/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_gazebo_ros_control_plugin.h
+++ b/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_gazebo_ros_control_plugin.h
@@ -1,0 +1,110 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  Copyright (c) 2013, The Johns Hopkins University
+ *  Copyright (c) 2014, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Jonathan Bohren, Felix Messmer
+   Desc:   Gazebo plugin for ros_control that allows 'hardware_interfaces' to be plugged in
+           using pluginlib. It extends gazebo_ros_control_plugin with harware_interface switching capability.
+*/
+
+// CobGazeboRosControlPlugin
+#include <gazebo_ros_control/gazebo_ros_control_plugin.h>
+#include <cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h>
+
+
+
+
+namespace cob_gazebo_ros_control
+{
+
+
+
+class GazeboControllerManager : public controller_manager::ControllerManager
+{
+  MultiHWInterfaceRobotHWSim *robot_hw_sim_;
+  
+public:
+
+  GazeboControllerManager(gazebo_ros_control::RobotHWSim *robot_hw,
+                          const ros::NodeHandle& nh=ros::NodeHandle())
+                        : controller_manager::ControllerManager(robot_hw, nh), robot_hw_sim_(static_cast<MultiHWInterfaceRobotHWSim*>(robot_hw)) {}
+  
+  bool notifyHardwareInterface(const std::list<hardware_interface::ControllerInfo> &info_list) 
+  {
+    //for (std::list<hardware_interface::ControllerInfo>::const_iterator it=info_list.begin(); it != info_list.end(); ++it)
+    //{
+      //ROS_DEBUG_STREAM("Name: " << it->name << ", Type: " << it->type << ", Hardware-Interface: " << it->hardware_interface);
+      //ROS_DEBUG("ResourcesSetLength: %zu", it->resources.size());
+    //}
+    
+    //canSwitchHWInterface
+    for (std::list<hardware_interface::ControllerInfo>::const_iterator list_it=info_list.begin(); list_it != info_list.end(); ++list_it)
+    {
+      for(std::set<std::string>::iterator set_it=list_it->resources.begin(); set_it!=list_it->resources.end(); ++set_it)
+      {
+        if(!robot_hw_sim_->canSwitchHWInterface(*set_it, list_it->hardware_interface))
+          return false;
+      }
+    }
+    
+    //doSwitchHWInterface
+    for (std::list<hardware_interface::ControllerInfo>::const_iterator list_it=info_list.begin(); list_it != info_list.end(); ++list_it)
+    {
+      for(std::set<std::string>::iterator set_it=list_it->resources.begin(); set_it!=list_it->resources.end(); ++set_it)
+      {
+        if(!robot_hw_sim_->doSwitchHWInterface(*set_it, list_it->hardware_interface))
+          return false;
+      }
+    }
+    
+    ROS_INFO("Done switching HW-Interface! Ready to switch Controllers!");
+    return true;
+  }
+};
+
+
+
+class MultiHWInterfaceGazeboRosControlPlugin : public gazebo_ros_control::GazeboRosControlPlugin
+{
+public:
+
+  // Overloaded Gazebo entry point
+  virtual void Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf);
+
+};
+
+
+}

--- a/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_gazebo_ros_control_plugin.h
+++ b/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_gazebo_ros_control_plugin.h
@@ -90,7 +90,7 @@ public:
       }
     }
     
-    ROS_INFO("Done switching HW-Interface! Ready to switch Controllers!");
+    ROS_DEBUG("Done switching HW-Interface! Ready to switch Controllers!");
     return true;
   }
 };

--- a/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h
+++ b/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h
@@ -1,0 +1,80 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  Copyright (c) 2013, The Johns Hopkins University
+ *  Copyright (c) 2014, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Johnathan Bohren, Felix Messmer
+   Desc:   Hardware Interface for any simulated robot in Gazebo supporting multiple hardware_interfaces
+*/
+
+#ifndef _COB_GAZEBO_ROS_CONTROL___MULTI_HW_INTERFACE_ROBOT_HW_SIM_H_
+#define _COB_GAZEBO_ROS_CONTROL___MULTI_HW_INTERFACE_ROBOT_HW_SIM_H_
+
+
+// cob_gazebo_ros_control
+#include <gazebo_ros_control/default_robot_hw_sim.h>
+
+
+
+namespace cob_gazebo_ros_control
+{
+
+class MultiHWInterfaceRobotHWSim : public gazebo_ros_control::DefaultRobotHWSim
+{
+public:
+
+  virtual bool initSim(
+    const std::string& robot_namespace,
+    ros::NodeHandle model_nh,
+    gazebo::physics::ModelPtr parent_model,
+    const urdf::Model *const urdf_model,
+    std::vector<transmission_interface::TransmissionInfo> transmissions);
+    
+  virtual bool canSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name);
+  virtual bool doSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name);
+
+protected:
+
+  std::map< std::string, std::set<std::string> > map_hwinterface_to_joints_;
+  std::map< std::string, ControlMethod > map_hwinterface_to_controlmethod_;
+  std::map< ControlMethod, std::vector<control_toolbox::Pid> > map_controlmethod_to_pidcontrollers_;
+
+};
+
+typedef boost::shared_ptr<MultiHWInterfaceRobotHWSim> MultiHWInterfaceRobotHWSimPtr;
+
+}
+
+#endif // #ifndef _COB_GAZEBO_ROS_CONTROL___MULTI_HW_INTERFACE_ROBOT_HW_SIM_H_

--- a/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h
+++ b/cob_gazebo_ros_control/include/cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h
@@ -69,7 +69,6 @@ protected:
 
   std::map< std::string, std::set<std::string> > map_hwinterface_to_joints_;
   std::map< std::string, ControlMethod > map_hwinterface_to_controlmethod_;
-  std::map< ControlMethod, std::vector<control_toolbox::Pid> > map_controlmethod_to_pidcontrollers_;
 
 };
 

--- a/cob_gazebo_ros_control/package.xml
+++ b/cob_gazebo_ros_control/package.xml
@@ -1,0 +1,45 @@
+<package>
+  <name>cob_gazebo_ros_control</name>
+  <version>0.6.0</version>
+  <description>
+    This package contains a specialization of the gazebo_ros_control plugin.
+    The cob_gazebo_ros_control plugin allows Multi-HardwareInterface-Support.
+  </description>
+
+  <maintainer email="fxm@ipa.fhg.de">Felix Messmer</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/cob_gazebo_ros_control</url>
+  <url type="bugtracker">https://github.com/ipa320/cob_gazebo_plugins/issues</url>
+  <url type="repository">https://github.com/ipa320/cob_gazebo_plugins</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend> 
+  <build_depend>gazebo</build_depend>
+  <build_depend>control_toolbox</build_depend> 
+  <build_depend>controller_manager</build_depend> 
+  <build_depend>pluginlib</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>transmission_interface</build_depend> 
+  <build_depend>joint_limits_interface</build_depend>
+  <build_depend>urdf</build_depend>
+  <build_depend>angles</build_depend>
+  <build_depend>gazebo_ros_control</build_depend>
+  
+  <run_depend>roscpp</run_depend>
+  <run_depend>gazebo</run_depend>
+  <run_depend>gazebo_ros</run_depend> 
+  <run_depend>control_toolbox</run_depend> 
+  <run_depend>controller_manager</run_depend> 
+  <run_depend>pluginlib</run_depend> 
+  <run_depend>transmission_interface</run_depend> 
+  <run_depend>urdf</run_depend>
+  <run_depend>angles</run_depend>
+  <run_depend>gazebo_ros_control</run_depend>
+
+  <export>
+    <gazebo_ros_control plugin="${prefix}/cob_gazebo_ros_control_plugins.xml"/>
+  </export>
+</package>

--- a/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
+++ b/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
@@ -62,7 +62,7 @@ void MultiHWInterfaceGazeboRosControlPlugin::Load(gazebo::physics::ModelPtr pare
   // Error message if the model couldn't be found
   if (!parent_model_)
   {
-    ROS_ERROR_STREAM_NAMED("loadThread","parent model is NULL");
+    ROS_ERROR_STREAM_NAMED("gazebo_ros_control","parent model is NULL");
     return;
   }
 
@@ -99,12 +99,12 @@ void MultiHWInterfaceGazeboRosControlPlugin::Load(gazebo::physics::ModelPtr pare
   {
     //robot_hw_sim_type_str_ = sdf_->Get<std::string>("robotSimType");
     robot_hw_sim_type_str_ = "cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim";
-    ROS_WARN_STREAM_NAMED("loadThread","Tag 'robotSimType' is currently ignored. Using default plugin for RobotHWSim \""<<robot_hw_sim_type_str_<<"\"");
+    ROS_WARN_STREAM_NAMED("gazebo_ros_control","Tag 'robotSimType' is currently ignored. Using default plugin for RobotHWSim \""<<robot_hw_sim_type_str_<<"\"");
   }
   else
   {
     robot_hw_sim_type_str_ = "cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim";
-    ROS_DEBUG_STREAM_NAMED("loadThread","Using default plugin for RobotHWSim (none specified in URDF/SDF)\""<<robot_hw_sim_type_str_<<"\"");
+    ROS_DEBUG_STREAM_NAMED("gazebo_ros_control","Using default plugin for RobotHWSim (none specified in URDF/SDF)\""<<robot_hw_sim_type_str_<<"\"");
   }
   
   // Get the Gazebo simulation period
@@ -168,7 +168,7 @@ void MultiHWInterfaceGazeboRosControlPlugin::Load(gazebo::physics::ModelPtr pare
     }
 
     // Create the controller manager
-    ROS_DEBUG_STREAM_NAMED("ros_control_plugin","Loading controller_manager");
+    ROS_DEBUG_STREAM_NAMED("gazebo_ros_control","Loading controller_manager");
     controller_manager_.reset
       (new cob_gazebo_ros_control::GazeboControllerManager(robot_hw_sim_.get(), model_nh_));
 

--- a/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
+++ b/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
@@ -97,7 +97,9 @@ void MultiHWInterfaceGazeboRosControlPlugin::Load(gazebo::physics::ModelPtr pare
   // Get the robot simulation interface type
   if(sdf_->HasElement("robotSimType"))
   {
-    robot_hw_sim_type_str_ = sdf_->Get<std::string>("robotSimType");
+    //robot_hw_sim_type_str_ = sdf_->Get<std::string>("robotSimType");
+    robot_hw_sim_type_str_ = "cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim";
+    ROS_WARN_STREAM_NAMED("loadThread","Tag 'robotSimType' is currently ignored. Using default plugin for RobotHWSim \""<<robot_hw_sim_type_str_<<"\"");
   }
   else
   {

--- a/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
+++ b/cob_gazebo_ros_control/src/multi_hw_interface_gazebo_ros_control_plugin.cpp
@@ -1,0 +1,189 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  Copyright (c) 2013, The Johns Hopkins University
+ *  Copyright (c) 2014, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Jonathan Bohren, Felix Messmer
+   Desc:   Gazebo plugin for ros_control that allows 'hardware_interfaces' to be plugged in
+           using pluginlib. It extends gazebo_ros_control_plugin with harware_interface switching capability.
+*/
+
+// Boost
+#include <boost/bind.hpp>
+
+#include <cob_gazebo_ros_control/multi_hw_interface_gazebo_ros_control_plugin.h>
+#include <urdf/model.h>
+
+namespace cob_gazebo_ros_control
+{
+
+
+// Overloaded Gazebo entry point
+void MultiHWInterfaceGazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf)
+{
+  ROS_INFO_STREAM_NAMED("gazebo_ros_control","Loading gazebo_ros_control plugin");
+
+  // Save pointers to the model
+  parent_model_ = parent;
+  sdf_ = sdf;
+
+  // Error message if the model couldn't be found
+  if (!parent_model_)
+  {
+    ROS_ERROR_STREAM_NAMED("loadThread","parent model is NULL");
+    return;
+  }
+
+  // Check that ROS has been initialized
+  if(!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM_NAMED("gazebo_ros_control","A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  // Get namespace for nodehandle
+  if(sdf_->HasElement("robotNamespace"))
+  {
+    robot_namespace_ = sdf_->GetElement("robotNamespace")->Get<std::string>();
+  }
+  else
+  {
+    robot_namespace_ = parent_model_->GetName(); // default
+  }
+
+  // Get robot_description ROS param name
+  if (sdf_->HasElement("robotParam"))
+  {
+    robot_description_ = sdf_->GetElement("robotParam")->Get<std::string>();
+  }
+  else
+  {
+    robot_description_ = "robot_description"; // default
+  }
+
+  // Get the robot simulation interface type
+  if(sdf_->HasElement("robotSimType"))
+  {
+    robot_hw_sim_type_str_ = sdf_->Get<std::string>("robotSimType");
+  }
+  else
+  {
+    robot_hw_sim_type_str_ = "cob_gazebo_ros_control/MultiHWInterfaceRobotHWSim";
+    ROS_DEBUG_STREAM_NAMED("loadThread","Using default plugin for RobotHWSim (none specified in URDF/SDF)\""<<robot_hw_sim_type_str_<<"\"");
+  }
+  
+  // Get the Gazebo simulation period
+  ros::Duration gazebo_period(parent_model_->GetWorld()->GetPhysicsEngine()->GetMaxStepSize());
+
+  // Decide the plugin control period
+  if(sdf_->HasElement("controlPeriod"))
+  {
+    control_period_ = ros::Duration(sdf_->Get<double>("controlPeriod"));
+
+    // Check the period against the simulation period
+    if( control_period_ < gazebo_period )
+    {
+      ROS_ERROR_STREAM_NAMED("gazebo_ros_control","Desired controller update period ("<<control_period_
+        <<" s) is faster than the gazebo simulation period ("<<gazebo_period<<" s).");
+    }
+    else if( control_period_ > gazebo_period )
+    {
+      ROS_WARN_STREAM_NAMED("gazebo_ros_control","Desired controller update period ("<<control_period_
+        <<" s) is slower than the gazebo simulation period ("<<gazebo_period<<" s).");
+    }
+  }
+  else
+  {
+    control_period_ = gazebo_period;
+    ROS_DEBUG_STREAM_NAMED("gazebo_ros_control","Control period not found in URDF/SDF, defaulting to Gazebo period of "
+      << control_period_);
+  }
+
+
+  // Get parameters/settings for controllers from ROS param server
+  model_nh_ = ros::NodeHandle(robot_namespace_);
+  ROS_INFO_NAMED("gazebo_ros_control", "Starting gazebo_ros_control plugin in namespace: %s", robot_namespace_.c_str());
+
+  // Read urdf from ros parameter server then
+  // setup actuators and mechanism control node.
+  // This call will block if ROS is not properly initialized.
+  const std::string urdf_string = getURDF(robot_description_);
+  if (!parseTransmissionsFromURDF(urdf_string))
+  {
+    ROS_ERROR_NAMED("gazebo_ros_control", "Error parsing URDF in gazebo_ros_control plugin, plugin not active.\n");
+    return;
+  }
+
+  // Load the RobotHWSim abstraction to interface the controllers with the gazebo model
+  try
+  {
+    robot_hw_sim_loader_.reset
+      (new pluginlib::ClassLoader<gazebo_ros_control::RobotHWSim>
+        ("gazebo_ros_control",
+          "gazebo_ros_control::RobotHWSim"));
+
+    robot_hw_sim_ = robot_hw_sim_loader_->createInstance(robot_hw_sim_type_str_);
+    urdf::Model urdf_model;
+    const urdf::Model *const urdf_model_ptr = urdf_model.initString(urdf_string) ? &urdf_model : NULL;
+
+    if(!robot_hw_sim_->initSim(robot_namespace_, model_nh_, parent_model_, urdf_model_ptr, transmissions_))
+    {
+      ROS_FATAL_NAMED("gazebo_ros_control","Could not initialize robot simulation interface");
+      return;
+    }
+
+    // Create the controller manager
+    ROS_DEBUG_STREAM_NAMED("ros_control_plugin","Loading controller_manager");
+    controller_manager_.reset
+      (new cob_gazebo_ros_control::GazeboControllerManager(robot_hw_sim_.get(), model_nh_));
+
+    // Listen to the update event. This event is broadcast every simulation iteration.
+    update_connection_ =
+      gazebo::event::Events::ConnectWorldUpdateBegin
+      (boost::bind(&MultiHWInterfaceGazeboRosControlPlugin::Update, this));
+
+  }
+  catch(pluginlib::LibraryLoadException &ex)
+  {
+    ROS_FATAL_STREAM_NAMED("gazebo_ros_control","Failed to create robot simulation interface loader: "<<ex.what());
+  }
+
+  ROS_INFO_NAMED("gazebo_ros_control", "Loaded gazebo_ros_control.");
+}
+
+// Register this plugin with the simulator
+GZ_REGISTER_MODEL_PLUGIN(MultiHWInterfaceGazeboRosControlPlugin);
+} // namespace

--- a/cob_gazebo_ros_control/src/multi_hw_interface_robot_hw_sim.cpp
+++ b/cob_gazebo_ros_control/src/multi_hw_interface_robot_hw_sim.cpp
@@ -1,0 +1,323 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  Copyright (c) 2013, The Johns Hopkins University
+ *  Copyright (c) 2014, Fraunhofer IPA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Dave Coleman, Johnathan Bohren, Felix Messmer
+   Desc:   Hardware Interface for any simulated robot in Gazebo supporting multiple hardware_interfaces
+*/
+
+
+// cob_gazebo_ros_control
+#include <cob_gazebo_ros_control/multi_hw_interface_robot_hw_sim.h>
+
+
+namespace cob_gazebo_ros_control
+{
+
+bool MultiHWInterfaceRobotHWSim::initSim(
+  const std::string& robot_namespace,
+  ros::NodeHandle model_nh,
+  gazebo::physics::ModelPtr parent_model,
+  const urdf::Model *const urdf_model,
+  std::vector<transmission_interface::TransmissionInfo> transmissions)
+{
+  // getJointLimits() searches joint_limit_nh for joint limit parameters. The format of each
+  // parameter's name is "joint_limits/<joint name>". An example is "joint_limits/axle_joint".
+  const ros::NodeHandle joint_limit_nh(model_nh, robot_namespace);
+
+  // Resize vectors to our DOF
+  n_dof_ = transmissions.size();
+  joint_names_.resize(n_dof_);
+  joint_types_.resize(n_dof_);
+  joint_lower_limits_.resize(n_dof_);
+  joint_upper_limits_.resize(n_dof_);
+  joint_effort_limits_.resize(n_dof_);
+  joint_control_methods_.resize(n_dof_);
+  pid_controllers_.resize(n_dof_);
+  map_hwinterface_to_joints_.clear();
+  map_hwinterface_to_controlmethod_.clear();
+  map_controlmethod_to_pidcontrollers_.clear();
+  joint_position_.resize(n_dof_);
+  joint_velocity_.resize(n_dof_);
+  joint_effort_.resize(n_dof_);
+  joint_effort_command_.resize(n_dof_);
+  joint_position_command_.resize(n_dof_);
+  joint_velocity_command_.resize(n_dof_);
+  
+  std::vector<control_toolbox::Pid> pid_controllers_pos;
+  pid_controllers_pos.resize(n_dof_);
+  map_controlmethod_to_pidcontrollers_.insert( std::pair< ControlMethod, std::vector<control_toolbox::Pid> >(POSITION_PID, pid_controllers_pos) );
+  std::vector<control_toolbox::Pid> pid_controllers_vel;
+  pid_controllers_vel.resize(n_dof_);
+  map_controlmethod_to_pidcontrollers_.insert( std::pair< ControlMethod, std::vector<control_toolbox::Pid> >(VELOCITY_PID, pid_controllers_vel) );
+
+  // Initialize values
+  for(unsigned int j=0; j < n_dof_; j++)
+  {
+    // Check that this transmission has one joint
+    if(transmissions[j].joints_.size() == 0)
+    {
+      ROS_WARN_STREAM_NAMED("default_robot_hw_sim","Transmission " << transmissions[j].name_
+        << " has no associated joints.");
+      continue;
+    }
+    else if(transmissions[j].joints_.size() > 1)
+    {
+      ROS_WARN_STREAM_NAMED("default_robot_hw_sim","Transmission " << transmissions[j].name_
+        << " has more than one joint. Currently the default robot hardware simulation "
+        << " interface only supports one.");
+      continue;
+    }
+
+    std::vector<std::string> joint_interfaces = transmissions[j].joints_[0].hardware_interfaces_;
+    if (joint_interfaces.empty() &&
+        !(transmissions[j].actuators_.empty()) &&
+        !(transmissions[j].actuators_[0].hardware_interfaces_.empty()))
+    {
+      // TODO: Deprecate HW interface specification in actuators in ROS J
+      joint_interfaces = transmissions[j].actuators_[0].hardware_interfaces_;
+      ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "The <hardware_interface> element of tranmission " <<
+        transmissions[j].name_ << " should be nested inside the <joint> element, not <actuator>. " <<
+        "The transmission will be properly loaded, but please update " <<
+        "your robot model to remain compatible with future versions of the plugin.");
+    }
+    if (joint_interfaces.empty())
+    {
+      ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
+        " of transmission " << transmissions[j].name_ << " does not specify any hardware interface. " <<
+        "Not adding it to the robot hardware simulation.");
+      continue;
+    }
+    else if (joint_interfaces.size() > 1)
+    {
+      ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
+        " of transmission " << transmissions[j].name_ << " specifies multiple hardware interfaces. " <<
+        "This feature is now available.");
+    }
+
+    // Add data from transmission
+    joint_names_[j] = transmissions[j].joints_[0].name_;
+    joint_position_[j] = 1.0;
+    joint_velocity_[j] = 0.0;
+    joint_effort_[j] = 1.0;  // N/m for continuous joints
+    joint_effort_command_[j] = 0.0;
+    joint_position_command_[j] = 0.0;
+    joint_velocity_command_[j] = 0.0;
+
+
+    // Create joint state interface for all joints
+    js_interface_.registerHandle(hardware_interface::JointStateHandle(
+        joint_names_[j], &joint_position_[j], &joint_velocity_[j], &joint_effort_[j]));
+    
+    // Decide what kind of command interface this actuator/joint has
+    hardware_interface::JointHandle joint_handle;
+      
+    // Parse all HW-Interfaces available for each joint and store information
+    for(unsigned int i=0; i<joint_interfaces.size(); i++)
+    {
+      // Debug
+      ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim","Loading joint '" << joint_names_[j]
+        << "' of type '" << joint_interfaces[i] << "'");
+      
+      // Add hardware interface and joint to map of map_hwinterface_to_joints_
+      // ToDo: hardcoded namespace 'hardware_interface'?
+      std::string hw_interface_type = "hardware_interface::"+joint_interfaces[i];
+      if(map_hwinterface_to_joints_.find(hw_interface_type)!=map_hwinterface_to_joints_.end())
+      {
+        ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "HW-Interface " << hw_interface_type << " already registered. Adding joint " << joint_names_[j] << " to list.");
+        std::map< std::string, std::set<std::string> >::iterator it;
+        it=map_hwinterface_to_joints_.find(hw_interface_type);
+        it->second.insert(joint_names_[j]);
+      }
+      else
+      {
+        ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "New HW-Interface registered " << hw_interface_type << ". Adding joint " << joint_names_[j] << " to list.");
+        std::set<std::string> supporting_joints;
+        supporting_joints.insert(joint_names_[j]);
+        map_hwinterface_to_joints_.insert( std::pair< std::string, std::set<std::string> >(hw_interface_type, supporting_joints) );
+      }
+      
+      if(joint_interfaces[i] == "EffortJointInterface")
+      {
+        // Create effort joint interface
+        if(i==0){ joint_control_methods_[j] = EFFORT; } //use first entry for startup
+        map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, EFFORT) );
+        
+        joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
+                                                      &joint_effort_command_[j]);
+        ej_interface_.registerHandle(joint_handle);
+        
+        registerJointLimits(joint_names_[j], joint_handle, EFFORT,
+                        joint_limit_nh, urdf_model,
+                        &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
+                        &joint_effort_limits_[j]);
+      }
+      else if(joint_interfaces[i] == "PositionJointInterface")
+      {
+        ControlMethod control_method = POSITION;
+        control_toolbox::Pid pid_controller;
+        
+        // Initialize the PID controller. If no PID gain values are found, use joint->SetAngle() or
+        // joint->SetVelocity() to control the joint.
+        const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/position/" +
+                                 joint_names_[j]);
+        if (pid_controller.init(nh, true))
+        {
+          control_method = POSITION_PID;
+          map_controlmethod_to_pidcontrollers_.find(control_method)->second[j]=pid_controller;
+        }
+          
+        // Create position joint interface
+        if(i==0){ joint_control_methods_[j] = control_method; } //use first entry for startup
+        map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, control_method) );
+          
+        joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
+                                                      &joint_position_command_[j]);
+        pj_interface_.registerHandle(joint_handle);
+        
+        registerJointLimits(joint_names_[j], joint_handle, control_method,
+                        joint_limit_nh, urdf_model,
+                        &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
+                        &joint_effort_limits_[j]);
+      }
+      else if(joint_interfaces[i] == "VelocityJointInterface")
+      {
+        ControlMethod control_method = VELOCITY;
+        control_toolbox::Pid pid_controller;
+        
+        // Initialize the PID controller. If no PID gain values are found, use joint->SetAngle() or
+        // joint->SetVelocity() to control the joint.
+        const ros::NodeHandle nh(model_nh, robot_namespace + "/gazebo_ros_control/pid_gains/velocity/" +
+                                 joint_names_[j]);
+        if (pid_controller.init(nh, true))
+        {
+          control_method = VELOCITY_PID;
+          map_controlmethod_to_pidcontrollers_.find(control_method)->second[j]=pid_controller;
+        }
+          
+        // Create velocity joint interface
+        if(i==0){ joint_control_methods_[j] = control_method; } //use first entry for startup
+        map_hwinterface_to_controlmethod_.insert( std::pair<std::string, ControlMethod>(hw_interface_type, control_method) );
+         
+        joint_handle = hardware_interface::JointHandle(js_interface_.getHandle(joint_names_[j]),
+                                                      &joint_velocity_command_[j]);
+        vj_interface_.registerHandle(joint_handle);
+        
+        registerJointLimits(joint_names_[j], joint_handle, control_method,
+                        joint_limit_nh, urdf_model,
+                        &joint_types_[j], &joint_lower_limits_[j], &joint_upper_limits_[j],
+                        &joint_effort_limits_[j]);
+      }
+      else
+      {
+        ROS_FATAL_STREAM_NAMED("default_robot_hw_sim","No matching hardware interface found for '"
+          << joint_interfaces[i] );
+        return false;
+      }
+    }
+
+    // Get the gazebo joint that corresponds to the robot joint.
+    //ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Getting pointer to gazebo joint: "
+    //  << joint_names_[j]);
+    gazebo::physics::JointPtr joint = parent_model->GetJoint(joint_names_[j]);
+    if (!joint)
+    {
+      ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "This robot has a joint named \"" << joint_names_[j]
+        << "\" which is not in the gazebo model.");
+      return false;
+    }
+    sim_joints_.push_back(joint);
+      
+    
+    // ToDo: Can a joint (gazebo::physics::JointPtr) be used for EFFORT if joint->SetMaxForce has been called before?
+    if (joint_control_methods_[j] == VELOCITY || joint_control_methods_[j] == POSITION)
+    {
+      // joint->SetMaxForce() must be called if joint->SetAngle() or joint->SetVelocity() are
+      // going to be called. joint->SetMaxForce() must *not* be called if joint->SetForce() is
+      // going to be called.
+      joint->SetMaxForce(0, joint_effort_limits_[j]);
+    }
+  }
+
+  // Register interfaces
+  registerInterface(&js_interface_);
+  registerInterface(&ej_interface_);
+  registerInterface(&pj_interface_);
+  registerInterface(&vj_interface_);
+
+  return true;
+}
+
+  
+bool MultiHWInterfaceRobotHWSim::canSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
+{
+  ROS_DEBUG_STREAM_NAMED("canSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
+  std::map< std::string, std::set<std::string> >::iterator it = map_hwinterface_to_joints_.find(hwinterface_name);
+  if(it->second.find(joint_name)!=it->second.end()) { return true; }
+  
+  ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "Joint " << joint_name << " does not provide a HW-Interface of type " << hwinterface_name);
+  return false;
+}
+
+bool MultiHWInterfaceRobotHWSim::doSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
+{
+  ROS_DEBUG_STREAM_NAMED("doSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
+  for(unsigned int i=0; i<joint_names_.size(); i++)
+  {
+    if(joint_names_[i] == joint_name)
+    {
+      if(map_hwinterface_to_controlmethod_.find(hwinterface_name)!=map_hwinterface_to_controlmethod_.end())
+      {
+        ControlMethod current_control_method = map_hwinterface_to_controlmethod_.find(hwinterface_name)->second;
+        joint_control_methods_[i] = current_control_method;
+        if(current_control_method == POSITION_PID || current_control_method == VELOCITY_PID)
+        {
+          pid_controllers_ = map_controlmethod_to_pidcontrollers_.find(current_control_method)->second;
+        }
+        
+        ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Joint " << joint_name << " now uses HW-Interface type: " << hwinterface_name);
+        return true;
+      }
+    }
+  }
+  
+  ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "An error occured while trying to switch HW-Interface for Joint " << joint_name << " (HW-Interface type: " << hwinterface_name << ")");
+  return false;
+}
+
+}
+
+PLUGINLIB_EXPORT_CLASS(cob_gazebo_ros_control::MultiHWInterfaceRobotHWSim, gazebo_ros_control::RobotHWSim)

--- a/cob_gazebo_ros_control/src/multi_hw_interface_robot_hw_sim.cpp
+++ b/cob_gazebo_ros_control/src/multi_hw_interface_robot_hw_sim.cpp
@@ -90,13 +90,13 @@ bool MultiHWInterfaceRobotHWSim::initSim(
     // Check that this transmission has one joint
     if(transmissions[j].joints_.size() == 0)
     {
-      ROS_WARN_STREAM_NAMED("default_robot_hw_sim","Transmission " << transmissions[j].name_
+      ROS_WARN_STREAM_NAMED("multi_hwi_robot_hw_sim","Transmission " << transmissions[j].name_
         << " has no associated joints.");
       continue;
     }
     else if(transmissions[j].joints_.size() > 1)
     {
-      ROS_WARN_STREAM_NAMED("default_robot_hw_sim","Transmission " << transmissions[j].name_
+      ROS_WARN_STREAM_NAMED("multi_hwi_robot_hw_sim","Transmission " << transmissions[j].name_
         << " has more than one joint. Currently the default robot hardware simulation "
         << " interface only supports one.");
       continue;
@@ -109,21 +109,21 @@ bool MultiHWInterfaceRobotHWSim::initSim(
     {
       // TODO: Deprecate HW interface specification in actuators in ROS J
       joint_interfaces = transmissions[j].actuators_[0].hardware_interfaces_;
-      ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "The <hardware_interface> element of tranmission " <<
+      ROS_WARN_STREAM_NAMED("multi_hwi_robot_hw_sim", "The <hardware_interface> element of tranmission " <<
         transmissions[j].name_ << " should be nested inside the <joint> element, not <actuator>. " <<
         "The transmission will be properly loaded, but please update " <<
         "your robot model to remain compatible with future versions of the plugin.");
     }
     if (joint_interfaces.empty())
     {
-      ROS_WARN_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
+      ROS_WARN_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
         " of transmission " << transmissions[j].name_ << " does not specify any hardware interface. " <<
         "Not adding it to the robot hardware simulation.");
       continue;
     }
     else if (joint_interfaces.size() > 1)
     {
-      ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
+      ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << transmissions[j].joints_[0].name_ <<
         " of transmission " << transmissions[j].name_ << " specifies multiple hardware interfaces. " <<
         "This feature is now available.");
     }
@@ -149,7 +149,7 @@ bool MultiHWInterfaceRobotHWSim::initSim(
     for(unsigned int i=0; i<joint_interfaces.size(); i++)
     {
       // Debug
-      ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim","Loading joint '" << joint_names_[j]
+      ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim","Loading joint '" << joint_names_[j]
         << "' of type '" << joint_interfaces[i] << "'");
       
       // Add hardware interface and joint to map of map_hwinterface_to_joints_
@@ -157,14 +157,14 @@ bool MultiHWInterfaceRobotHWSim::initSim(
       std::string hw_interface_type = "hardware_interface::"+joint_interfaces[i];
       if(map_hwinterface_to_joints_.find(hw_interface_type)!=map_hwinterface_to_joints_.end())
       {
-        ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "HW-Interface " << hw_interface_type << " already registered. Adding joint " << joint_names_[j] << " to list.");
+        ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "HW-Interface " << hw_interface_type << " already registered. Adding joint " << joint_names_[j] << " to list.");
         std::map< std::string, std::set<std::string> >::iterator it;
         it=map_hwinterface_to_joints_.find(hw_interface_type);
         it->second.insert(joint_names_[j]);
       }
       else
       {
-        ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "New HW-Interface registered " << hw_interface_type << ". Adding joint " << joint_names_[j] << " to list.");
+        ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "New HW-Interface registered " << hw_interface_type << ". Adding joint " << joint_names_[j] << " to list.");
         std::set<std::string> supporting_joints;
         supporting_joints.insert(joint_names_[j]);
         map_hwinterface_to_joints_.insert( std::pair< std::string, std::set<std::string> >(hw_interface_type, supporting_joints) );
@@ -243,19 +243,19 @@ bool MultiHWInterfaceRobotHWSim::initSim(
       }
       else
       {
-        ROS_FATAL_STREAM_NAMED("default_robot_hw_sim","No matching hardware interface found for '"
+        ROS_FATAL_STREAM_NAMED("multi_hwi_robot_hw_sim","No matching hardware interface found for '"
           << joint_interfaces[i] );
         return false;
       }
     }
 
     // Get the gazebo joint that corresponds to the robot joint.
-    //ROS_DEBUG_STREAM_NAMED("default_robot_hw_sim", "Getting pointer to gazebo joint: "
+    //ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Getting pointer to gazebo joint: "
     //  << joint_names_[j]);
     gazebo::physics::JointPtr joint = parent_model->GetJoint(joint_names_[j]);
     if (!joint)
     {
-      ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "This robot has a joint named \"" << joint_names_[j]
+      ROS_ERROR_STREAM_NAMED("multi_hwi_robot_hw_sim", "This robot has a joint named \"" << joint_names_[j]
         << "\" which is not in the gazebo model.");
       return false;
     }
@@ -284,17 +284,17 @@ bool MultiHWInterfaceRobotHWSim::initSim(
   
 bool MultiHWInterfaceRobotHWSim::canSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
 {
-  ROS_DEBUG_STREAM_NAMED("canSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
+  ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
   std::map< std::string, std::set<std::string> >::iterator it = map_hwinterface_to_joints_.find(hwinterface_name);
   if(it->second.find(joint_name)!=it->second.end()) { return true; }
   
-  ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "Joint " << joint_name << " does not provide a HW-Interface of type " << hwinterface_name);
+  ROS_ERROR_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << joint_name << " does not provide a HW-Interface of type " << hwinterface_name);
   return false;
 }
 
 bool MultiHWInterfaceRobotHWSim::doSwitchHWInterface(const std::string &joint_name, const std::string &hwinterface_name)
 {
-  ROS_DEBUG_STREAM_NAMED("doSwitchHWInterface", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
+  ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << joint_name << " requests HW-Interface of type " << hwinterface_name);
   readSim(ros::Time(), ros::Duration());
   for(unsigned int i=0; i<joint_names_.size(); i++)
   {
@@ -337,14 +337,14 @@ bool MultiHWInterfaceRobotHWSim::doSwitchHWInterface(const std::string &joint_na
           pid_controllers_ = map_controlmethod_to_pidcontrollers_.find(current_control_method)->second;
         }
         
-        ROS_DEBUG_STREAM("Joint " << joint_name << " now uses HW-Interface type: " << hwinterface_name);
-        ROS_DEBUG_STREAM("Joint " << joint_name << " PosCommand: " << joint_position_command_[i] << " VelCommand: " << joint_velocity_command_[i] << " EffCommand: " << joint_effort_command_[i]);
+        ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << joint_name << " now uses HW-Interface type: " << hwinterface_name);
+        ROS_DEBUG_STREAM_NAMED("multi_hwi_robot_hw_sim", "Joint " << joint_name << " PosCommand: " << joint_position_command_[i] << " VelCommand: " << joint_velocity_command_[i] << " EffCommand: " << joint_effort_command_[i]);
         return true;
       }
     }
   }
   
-  ROS_ERROR_STREAM_NAMED("default_robot_hw_sim", "An error occured while trying to switch HW-Interface for Joint " << joint_name << " (HW-Interface type: " << hwinterface_name << ")");
+  ROS_ERROR_STREAM_NAMED("multi_hwi_robot_hw_sim", "An error occured while trying to switch HW-Interface for Joint " << joint_name << " (HW-Interface type: " << hwinterface_name << ")");
   return false;
 }
 


### PR DESCRIPTION
This feature has originally been proposed to [gazebo_ros_pkgs](https://github.com/ros-simulation/gazebo_ros_pkgs).
I'm posting the relevant PullRequests for the record:
[gazebo_ros_pkgs#256](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256)
[gazebo_ros_pkgs#266](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/266)
[gazebo_ros_pkgs#267](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/267)

This feature still requires [ros_control#184](https://github.com/ros-controls/ros_control/pull/184) to be merged!

Additional features will follow...
