### PR TITLE
fix catkin_package DEPENDS warning

### DIFF
--- a/cob_gazebo_ros_control/CMakeLists.txt
+++ b/cob_gazebo_ros_control/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(gazebo REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS controller_manager gazebo_ros_control gazebo_ros hardware_interface joint_limits_interface pluginlib roscpp transmission_interface urdf
-  DEPENDS gazebo
+  #DEPENDS gazebo
   INCLUDE_DIRS include
   LIBRARIES hwi_switch_gazebo_ros_control hwi_switch_robot_hw_sim
 )


### PR DESCRIPTION
fixes
```
CMake Warning at /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:166 (message):

  catkin_package() DEPENDS on 'gazebo' but neither 'gazebo_INCLUDE_DIRS' nor

  'gazebo_LIBRARIES' is defined.

Call Stack (most recent call first):

  /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)

  CMakeLists.txt:10 (catkin_package)
```

explanation: `gazebo` does not comply to recommended naming scheme - package name `gazebo` uses `GAZEBO_LIBRARIES`/`GAZEBO_INCLUDES_DIRS` instead of `gazebo_LIBRARIES`/`gazebo_INCLUDES_DIRS`