### PR TITLE
Fix wrong array index occuring if using joint filtering

### DIFF
--- a/cob_gazebo_ros_control/src/hwi_switch_robot_hw_sim.cpp
+++ b/cob_gazebo_ros_control/src/hwi_switch_robot_hw_sim.cpp
@@ -150,7 +150,7 @@ bool HWISwitchRobotHWSim::initSim(
       // Deprecated Syntax handling
       std::string& hardware_interface = joint_interfaces[i];
       if(hardware_interface == "EffortJointInterface" || hardware_interface == "PositionJointInterface" || hardware_interface == "VelocityJointInterface") {
-        ROS_WARN_STREAM("Deprecated syntax, please prepend 'hardware_interface/' to '" << hardware_interface << "' within the <hardwareInterface> tag in joint '" << joint_names_[j] << "'.");
+        ROS_WARN_STREAM("Deprecated syntax, please prepend 'hardware_interface/' to '" << hardware_interface << "' within the <hardwareInterface> tag in joint '" << joint_names_[index] << "'.");
         hardware_interface = "hardware_interface/"+joint_interfaces[i];
       }
 
@@ -257,7 +257,7 @@ bool HWISwitchRobotHWSim::initSim(
       // going to be called. joint->SetMaxForce() must *not* be called if joint->SetForce() is
       // going to be called.
       #if GAZEBO_MAJOR_VERSION > 2
-        joint->SetParam("fmax", 0, joint_effort_limits_[j]);
+        joint->SetParam("fmax", 0, joint_effort_limits_[index]);
       #else
         joint->SetMaxForce(0, joint_effort_limits_[index]);
       #endif


### PR DESCRIPTION
This PR fixes two problems in the libhwi_switch_gazebo_ros_control Gazebo plugin if joint filtering is enabled. If joint filtering is enabled then the number of transmissions is not equal to the controlled DoF.

1) This caused a segfault if the deprecated hardware interface definition is used in the URDF as the wrong index is used in the warning message.

2) The joint effort limits were set wrongly for Gazebo version > 2.

I replaced the wrong index "j" (referring to the transmission array) with the correct index "index", which corresponds to the controlled joint.